### PR TITLE
Add startup test for CalDAV reminder bot

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -51,8 +51,8 @@ class Config:
 class Reminder:
     """Class representing a reminder."""
     dt: datetime
-    valarm: Optional[caldav.vobject.base.Component] = field(compare=False, default=None)
     vevent: caldav.vobject = field(compare=False)
+    valarm: Optional[caldav.vobject.base.Component] = field(compare=False, default=None)
 
 
 @dataclass()
@@ -364,7 +364,7 @@ class Worker:
             return remove_empty_lines(msg)
         return f'<b>{reminder.vevent.summary.value}</b>\r\n{format_date(reminder.vevent.dtstart.value)}'
 
-if __name__ == '__main__':
+def main() -> None:
     """Main entry point for the script."""
     config = Config()
 
@@ -381,9 +381,17 @@ if __name__ == '__main__':
         sys.exit(1)
 
     caldav_handler = CaldavHandler(config)
-    result = caldav_handler.login(caldav_url=config.CALDAV_URL, username=config.CALDAV_USERNAME, password=config.CALDAV_PASSWORD)
+    result = caldav_handler.login(
+        caldav_url=config.CALDAV_URL,
+        username=config.CALDAV_USERNAME,
+        password=config.CALDAV_PASSWORD,
+    )
     if result is False:
         logging.error('Cannot start: Login failed')
         sys.exit(1)
     worker = Worker(config, caldav_handler)
     worker.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_bot_runs.py
+++ b/tests/test_bot_runs.py
@@ -1,0 +1,35 @@
+"""Tests that the bot starts with machine environment variables."""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+
+REQUIRED_ENV_VARS = [
+    "CALDAV_URL",
+    "CALDAV_USERNAME",
+    "CALDAV_PASSWORD",
+    "CALENDAR_IDS",
+    "TELEGRAM_BOT_TOKEN",
+    "TELEGRAM_CHAT_ID",
+]
+
+missing = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+
+
+@pytest.mark.skipif(missing, reason=f"Missing environment variables: {', '.join(missing)}")
+def test_bot_runs_with_machine_env():
+    """Run the bot using machine environment variables and ensure it stays alive."""
+    proc = subprocess.Popen([sys.executable, "-m", "src.app"], env=os.environ.copy())
+    try:
+        time.sleep(5)
+        assert proc.poll() is None
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()


### PR DESCRIPTION
## Summary
- add a `main` entrypoint to app so it can be invoked programmatically
- fix Reminder dataclass field order
- test running the bot with machine environment variables using a subprocess

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d80ba2d483339b92ded505239017